### PR TITLE
Add getMostRecentLocalEventNumber() and supporting index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-ledger-consensus-continuity-storage ChangeLog
 
+## 5.0.0 - TBD
+
+### Changed
+- **BREAKING**: `events.getHead` takes `peerId` instead of `creatorId`.
+- **BREAKING**: `events.getAvgConsensusTime` takes `peerId` instead of `creatorId`.
+- **BREAKING**: `events.getStartHash` takes `peerId` instead of `creatorId`.
+
 ## 4.0.0 - 2021-04-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # bedrock-ledger-consensus-continuity-storage ChangeLog
 
-## 5.0.0 - TBD
+## 5.0.0 - 2021-07-xx
+
+### Added
+- Add getMostRecentLocalEventNumber() and supporting index.
 
 ### Changed
 - **BREAKING**: `events.getHead` takes `peerId` instead of `creatorId`.
-- **BREAKING**: `events.getAvgConsensusTime` takes `peerId` instead of `creatorId`.
+- **BREAKING**: `events.getAvgConsensusTime` takes `peerId` instead of
+  `creatorId`.
 
 ### Removed
 - **BREAKING**: `events.getStartHash` has been removed.
 - **BREAKING**: `events.aggregateHistory` has been removed.
+- Remove getConsensusProofPeers test in preparation for feature removal.
 
 ## 4.0.0 - 2021-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Changed
 - **BREAKING**: `events.getHead` takes `peerId` instead of `creatorId`.
 - **BREAKING**: `events.getAvgConsensusTime` takes `peerId` instead of `creatorId`.
-- **BREAKING**: `events.getStartHash` takes `peerId` instead of `creatorId`.
+
+### Removed
+- **BREAKING**: `events.getStartHash` has been removed.
 
 ## 4.0.0 - 2021-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Removed
 - **BREAKING**: `events.getStartHash` has been removed.
+- **BREAKING**: `events.aggregateHistory` has been removed.
 
 ## 4.0.0 - 2021-04-29
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -177,27 +177,6 @@ api.getMergeEventPeers = async function({blockHeight, explain = false}) {
   return this.collection.distinct('meta.continuity2017.creator', query);
 };
 
-// FIXME: remove this, no longer used
-// used for node catchup
-api.getStartHash = async function(
-  {peerId, explain = false, targetGeneration}) {
-  const query = {
-    'meta.continuity2017.type': 'm',
-    'meta.continuity2017.creator': peerId,
-    'meta.continuity2017.generation': targetGeneration
-  };
-  const projection = {_id: 0, 'meta.eventHash': 1};
-  const cursor = this.collection.find(query, {projection}).limit(1);
-  if(explain) {
-    return cursor.explain('executionStats');
-  }
-  const [{meta}] = await cursor.toArray();
-  if(!meta) {
-    return null;
-  }
-  return meta.eventHash;
-};
-
 api.hasOutstandingParentHashCommitments = async function({
   basisBlockHeight = 0, explain = false
 } = {}) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -70,18 +70,18 @@ api.aggregateHistory = async function({
 };
 
 // get the average time(ms) to consensus for the last <limit> merge events
-// for the specified creatorId. The creatorId specified should be for the local
+// for the specified peerId. The peerId specified should be for the local
 // voter/creator. This is because it is only for local events that we can
 // compare `meta.created` and `meta.consensDate` and get a meaningful value.
 // this is useful in monitoring tools like bedrock-ledger-test
 // it is currently not being executed anywhere in the ledger core
 // this is *not* a covered query and it involves inspecting <limit> documents
 api.getAvgConsensusTime = async function(
-  {creatorId, explain = false, limit = 100}) {
+  {peerId, explain = false, limit = 100}) {
   const cursor = await this.collection.aggregate([
     {$match: {
       'meta.consensus': true, 'meta.continuity2017.type': 'm',
-      'meta.continuity2017.creator': creatorId
+      'meta.continuity2017.creator': peerId
     }},
     {$sort: {'meta.continuity2017.generation': -1}},
     {$limit: limit},
@@ -107,19 +107,19 @@ api.getAvgConsensusTime = async function(
 /**
  * Get the head based on the specified parameters.
  *
- * @param {string} [creatorId] the creator.
+ * @param {string} [peerId] the creator.
  * @param {integer} [generation] the head generation.
  * @param {boolean} [explain] return statistics for query profiling.
  *
  * @returns {Promise} the head information.
  */
-api.getHead = async function({creatorId, explain = false, generation}) {
+api.getHead = async function({peerId, explain = false, generation}) {
   // NOTE: all merge events are assigned a generation
   const query = {
     'meta.continuity2017.type': 'm',
   };
-  if(creatorId) {
-    query['meta.continuity2017.creator'] = creatorId;
+  if(peerId) {
+    query['meta.continuity2017.creator'] = peerId;
   }
   // must be able to query for generation === 0
   if(_.isNumber(generation)) {
@@ -180,10 +180,10 @@ api.getMergeEventPeers = async function({blockHeight, explain = false}) {
 // FIXME: remove this, no longer used
 // used for node catchup
 api.getStartHash = async function(
-  {creatorId, explain = false, targetGeneration}) {
+  {peerId, explain = false, targetGeneration}) {
   const query = {
     'meta.continuity2017.type': 'm',
-    'meta.continuity2017.creator': creatorId,
+    'meta.continuity2017.creator': peerId,
     'meta.continuity2017.generation': targetGeneration
   };
   const projection = {_id: 0, 'meta.eventHash': 1};

--- a/lib/events.js
+++ b/lib/events.js
@@ -126,9 +126,10 @@ api.getMergeEventPeers = async function({blockHeight, explain = false}) {
 /**
  * Get the most recent local event number.
  *
- * @param {boolean} [explain] return statistics for query profiling.
+ * @param {boolean} [explain=false] return statistics for query profiling.
  *
- * @returns {Promise} the most recent local event number.
+ * @returns {Promise<object>} an object with `localEventNumber` set to the most recent
+ *   local event number.
  */
 api.getMostRecentLocalEventNumber = async function({explain = false} = {}) {
   const projection = {_id: 0, 'meta.continuity2017.localEventNumber': 1};

--- a/lib/events.js
+++ b/lib/events.js
@@ -128,8 +128,8 @@ api.getMergeEventPeers = async function({blockHeight, explain = false}) {
  *
  * @param {boolean} [explain=false] return statistics for query profiling.
  *
- * @returns {Promise<object>} an object with `localEventNumber` set to the most recent
- *   local event number.
+ * @returns {Promise<object>} an object with `localEventNumber` set to the
+ *   most recent local event number.
  */
 api.getMostRecentLocalEventNumber = async function({explain = false} = {}) {
   const projection = {_id: 0, 'meta.continuity2017.localEventNumber': 1};

--- a/lib/events.js
+++ b/lib/events.js
@@ -71,7 +71,7 @@ api.aggregateHistory = async function({
 
 // get the average time(ms) to consensus for the last <limit> merge events
 // for the specified peerId. The peerId specified should be for the local
-// voter/creator. This is because it is only for local events that we can
+// peer. This is because it is only for local events that we can
 // compare `meta.created` and `meta.consensusDate` and get a meaningful value.
 // this is useful in monitoring tools like bedrock-ledger-test
 // it is currently not being executed anywhere in the ledger core

--- a/lib/events.js
+++ b/lib/events.js
@@ -123,6 +123,31 @@ api.getMergeEventPeers = async function({blockHeight, explain = false}) {
   return this.collection.distinct('meta.continuity2017.creator', query);
 };
 
+/**
+ * Get the most recent local event number.
+ *
+ * @param {boolean} [explain] return statistics for query profiling.
+ *
+ * @returns {Promise} the most recent local event number.
+ */
+api.getMostRecentLocalEventNumber = async function({explain = false} = {}) {
+  const projection = {_id: 0, 'meta.continuity2017.localEventNumber': 1};
+  const sort = {'meta.continuity2017.localEventNumber': -1};
+  const cursor = await this.collection.find({}, {projection})
+    .sort(sort).limit(1);
+  if(explain) {
+    return cursor.explain('executionStats');
+  }
+
+  const records = await cursor.toArray();
+  if(records.length === 0) {
+    return {localEventNumber: 0};
+  }
+
+  const [{meta: {continuity2017: {localEventNumber}}}] = records;
+  return {localEventNumber};
+};
+
 api.hasOutstandingParentHashCommitments = async function({
   basisBlockHeight = 0, explain = false
 } = {}) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -72,7 +72,7 @@ api.aggregateHistory = async function({
 // get the average time(ms) to consensus for the last <limit> merge events
 // for the specified peerId. The peerId specified should be for the local
 // voter/creator. This is because it is only for local events that we can
-// compare `meta.created` and `meta.consensDate` and get a meaningful value.
+// compare `meta.created` and `meta.consensusDate` and get a meaningful value.
 // this is useful in monitoring tools like bedrock-ledger-test
 // it is currently not being executed anywhere in the ledger core
 // this is *not* a covered query and it involves inspecting <limit> documents

--- a/lib/events.js
+++ b/lib/events.js
@@ -107,7 +107,7 @@ api.getAvgConsensusTime = async function(
 /**
  * Get the head based on the specified parameters.
  *
- * @param {string} [peerId] the creator.
+ * @param {string} [peerId] the ID of the peer that created the head; its creator.
  * @param {integer} [generation] the head generation.
  * @param {boolean} [explain] return statistics for query profiling.
  *

--- a/lib/events.js
+++ b/lib/events.js
@@ -14,61 +14,6 @@ api._stat = async function() {
   console.log('EVENT COLLECTION INDEXES', JSON.stringify(r, null, 2));
 };
 
-// FIXME: remove this, no longer used
-api.aggregateHistory = async function({
-  creatorFilter, creatorRestriction, eventTypeFilter, explain = false,
-  startParentHash}) {
-  // regular events *should* be included, regardless of created
-  const restrictSearchWithMatch = {
-    $nor: []
-  };
-  if(creatorRestriction && creatorRestriction.length !== 0) {
-    creatorRestriction.forEach(r => restrictSearchWithMatch.$nor.push({
-      'meta.continuity2017.type': 'm',
-      'meta.continuity2017.creator': r.creator,
-      'meta.continuity2017.generation': {$lte: r.generation}
-    }));
-  }
-
-  if(Array.isArray(creatorFilter) && creatorFilter.length !== 0) {
-    restrictSearchWithMatch.$nor.push(
-      {'meta.continuity2017.creator': {$in: creatorFilter}});
-  }
-
-  if(eventTypeFilter) {
-    const type = eventTypeFilter === 'ContinuityMergeEvent' ? 'm' : 'r';
-    restrictSearchWithMatch['meta.continuity2017.type'] = type;
-  }
-  const pipeline = [
-    {$match: {
-      'meta.eventHash': {$in: startParentHash}, 'meta.continuity2017.type': 'm'
-    }},
-    {$group: {
-      _id: null,
-      startWith: {$addToSet: '$meta.eventHash'}
-    }},
-    {$graphLookup: {
-      from: this.collection.collectionName,
-      startWith: '$startWith',
-      connectFromField: 'event.parentHash',
-      connectToField: 'meta.eventHash',
-      as: '_parents',
-      restrictSearchWithMatch
-    }},
-    {$project: {
-      _id: 0, '_parents.meta.eventHash': 1, '_parents.event.parentHash': 1
-    }},
-    {$unwind: '$_parents'},
-    {$replaceRoot: {newRoot: '$_parents'}},
-  ];
-  const cursor = await this.collection.aggregate(
-    pipeline, {allowDiskUse: true});
-  if(explain) {
-    return cursor.explain('executionStats');
-  }
-  return cursor.toArray();
-};
-
 // get the average time(ms) to consensus for the last <limit> merge events
 // for the specified peerId. The peerId specified should be for the local
 // peer. This is because it is only for local events that we can
@@ -107,7 +52,8 @@ api.getAvgConsensusTime = async function(
 /**
  * Get the head based on the specified parameters.
  *
- * @param {string} [peerId] the ID of the peer that created the head; its creator.
+ * @param {string} [peerId] the ID of the peer that created the head;
+ *   its creator.
  * @param {integer} [generation] the head generation.
  * @param {boolean} [explain] return statistics for query profiling.
  *

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -155,8 +155,8 @@ module.exports = {
         // for getting sorted event summaries for gossip
         collection: collections.eventCollection,
         fields: {
-          'meta.blockHeight': 1,
           'meta.continuity2017.localEventNumber': 1,
+          'meta.blockHeight': 1,
           // used to cover queries
           'meta.continuity2017.type': 1,
           'meta.continuity2017.creator': 1,

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -152,6 +152,16 @@ module.exports = {
         },
         options: {
           sparse: false, unique: false, background: false,
+          name: 'event.continuity2017.blockHeight.localEventNumber'
+        }
+      }, {
+        // for getting the most recent local event number
+        collection: collections.eventCollection,
+        fields: {
+          'meta.continuity2017.localEventNumber': -1
+        },
+        options: {
+          sparse: false, unique: true, background: false,
           name: 'event.continuity2017.localEventNumber'
         }
       }, {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -74,25 +74,8 @@ module.exports = {
             'meta.consensus': false,
           }
         }
-      }, /*{
-        // FIXME: remove this index if no longer used, as `aggregateHistory`
-        // is no longer used
-        collection: collections.eventCollection,
-        fields: {
-          'meta.eventHash': 1,
-          'event.parentHash': 1,
-          'meta.continuity2017.type': 1,
-          'meta.continuity2017.creator': 1,
-          'meta.continuity2017.generation': 1,
-        },
-        options: {
-          sparse: false, unique: true, background: false,
-          // this index is getting used based on stats, presumably by
-          // aggregateHistory, however index use in $graphLookup is difficult
-          // to assess
-          name: 'event.continuity2017.aggregateHistory'
-        }
-      }, */{
+      },
+      {
         // for validating that peer heads sent by the client during gossip
         // and getting their `localReplayNumber`
         collection: collections.eventCollection,

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -104,18 +104,18 @@ describe('Continuity Storage', () => {
     describe('getAvgConsensusTime', () => {
       it('produces a result', async () => {
         const {getAvgConsensusTime} = _getEventMethods();
-        // the only creatorId in the network
-        const [creatorId] = testCreatorIds;
-        const r = await getAvgConsensusTime({creatorId});
+        // the only peerId in the network
+        const [peerId] = testCreatorIds;
+        const r = await getAvgConsensusTime({peerId});
         r.should.be.an('object');
         should.exist(r.avgConsensusTime);
         r.avgConsensusTime.should.be.a('number');
       });
       it('is indexed properly', async () => {
         const {getAvgConsensusTime} = _getEventMethods();
-        // the only creatorId in the network
-        const [creatorId] = testCreatorIds;
-        const r = await getAvgConsensusTime({creatorId, explain: true});
+        // the only peerId in the network
+        const [peerId] = testCreatorIds;
+        const r = await getAvgConsensusTime({peerId, explain: true});
         const {indexName} = r.stages[0].$cursor.queryPlanner.winningPlan
           .inputStage;
         indexName.should.equal('event.continuity2017.type.1');
@@ -126,8 +126,8 @@ describe('Continuity Storage', () => {
       it('returns the proper head', async () => {
         const {getHead} = _getEventMethods();
         // FIXME: change to `peerId`
-        const [creatorId] = testCreatorIds;
-        const result = await getHead({creatorId});
+        const [peerId] = testCreatorIds;
+        const result = await getHead({peerId});
         result.should.be.an('array');
         result.should.have.length(1);
         const record = result[0];
@@ -137,13 +137,13 @@ describe('Continuity Storage', () => {
         eventHash.should.be.a('string');
         should.exist(record.meta.continuity2017);
         const {creator, generation} = record.meta.continuity2017;
-        creator.should.equal(creatorId);
+        creator.should.equal(peerId);
         generation.should.equal(1);
       });
-      it('is properly indexed for creatorId parameter', async () => {
+      it('is properly indexed for peerId parameter', async () => {
         const {getHead} = _getEventMethods();
-        const [creatorId] = testCreatorIds;
-        const r = await getHead({creatorId, explain: true});
+        const [peerId] = testCreatorIds;
+        const r = await getHead({peerId, explain: true});
         const {indexName} = r.queryPlanner.winningPlan.inputStage.inputStage;
         indexName.should.equal('event.continuity2017.type.1');
         const {executionStats: s} = r;
@@ -174,24 +174,24 @@ describe('Continuity Storage', () => {
     describe.skip('aggregateHistory', () => {
       it('produces a result', async () => {
         const {getHead} = _getEventMethods();
-        const [creatorId] = testCreatorIds;
-        const head = await getHead({creatorId});
+        const [peerId] = testCreatorIds;
+        const head = await getHead({peerId});
         const [{meta: {eventHash: startHash}}] = head;
         const startParentHash = [startHash];
         const {aggregateHistory} = _getEventMethods();
-        const creatorRestriction = [{creator: creatorId, generation: 0}];
+        const creatorRestriction = [{creator: peerId, generation: 0}];
         const r = await aggregateHistory(
           {creatorRestriction, startHash, startParentHash});
         r.should.have.length(4);
       });
       it('is properly indexed', async () => {
         const {getHead} = _getEventMethods();
-        const [creatorId] = testCreatorIds;
-        const head = await getHead({creatorId});
+        const [peerId] = testCreatorIds;
+        const head = await getHead({peerId});
         const [{meta: {eventHash: startHash}}] = head;
         const startParentHash = [startHash];
         const {aggregateHistory} = _getEventMethods();
-        const creatorRestriction = [{creator: creatorId, generation: 0}];
+        const creatorRestriction = [{creator: peerId, generation: 0}];
         const r = await aggregateHistory(
           {creatorRestriction, explain: true, startHash, startParentHash});
         should.exist(r);
@@ -230,9 +230,9 @@ describe('Continuity Storage', () => {
         const r = await getMergeEventPeers({blockHeight});
         r.should.be.an('array');
         r.should.have.length(1);
-        const [creatorId] = r;
-        // the only creatorId in the network
-        creatorId.should.equal(testCreatorIds[0]);
+        const [peerId] = r;
+        // the only peerId in the network
+        peerId.should.equal(testCreatorIds[0]);
       });
       it('is properly indexed', async () => {
         const {getMergeEventPeers} = _getEventMethods();
@@ -251,17 +251,17 @@ describe('Continuity Storage', () => {
     describe.skip('getStartHash', () => {
       it('produces a result', async () => {
         const {getStartHash} = _getEventMethods();
-        const [creatorId] = testCreatorIds;
+        const [peerId] = testCreatorIds;
         const targetGeneration = 1;
-        const r = await getStartHash({creatorId, targetGeneration});
+        const r = await getStartHash({peerId, targetGeneration});
         r.should.be.a.string;
       });
       it('is properly indexed', async () => {
         const {getStartHash} = _getEventMethods();
-        const [creatorId] = testCreatorIds;
+        const [peerId] = testCreatorIds;
         const targetGeneration = 1;
         const r = await getStartHash(
-          {creatorId, explain: true, targetGeneration});
+          {peerId, explain: true, targetGeneration});
         const {executionStats: s} = r;
         const {indexName} = r.queryPlanner.winningPlan.inputStage.inputStage;
         indexName.should.equal('event.continuity2017.type.1');

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -11,7 +11,7 @@ const peers = [];
 let ledgerNode;
 const blockMethods = ['getConsensusProofPeers'];
 const eventMethods = [
-  'aggregateHistory', 'hasOutstandingParentHashCommitments',
+  'hasOutstandingParentHashCommitments',
   'hasOutstandingRegularEvents',
   'getAvgConsensusTime', 'getHead', 'getMergeEventHashes',
   'getMergeEventPeers', 'setEffectiveConfiguration', '_stat'
@@ -169,36 +169,6 @@ describe('Continuity Storage', () => {
         s.totalDocsExamined.should.equal(0);
       });
     }); // end getHeads
-
-    // FIXME: skipped due to pending removal of this method
-    describe.skip('aggregateHistory', () => {
-      it('produces a result', async () => {
-        const {getHead} = _getEventMethods();
-        const [peerId] = testCreatorIds;
-        const head = await getHead({peerId});
-        const [{meta: {eventHash: startHash}}] = head;
-        const startParentHash = [startHash];
-        const {aggregateHistory} = _getEventMethods();
-        const creatorRestriction = [{creator: peerId, generation: 0}];
-        const r = await aggregateHistory(
-          {creatorRestriction, startHash, startParentHash});
-        r.should.have.length(4);
-      });
-      it('is properly indexed', async () => {
-        const {getHead} = _getEventMethods();
-        const [peerId] = testCreatorIds;
-        const head = await getHead({peerId});
-        const [{meta: {eventHash: startHash}}] = head;
-        const startParentHash = [startHash];
-        const {aggregateHistory} = _getEventMethods();
-        const creatorRestriction = [{creator: peerId, generation: 0}];
-        const r = await aggregateHistory(
-          {creatorRestriction, explain: true, startHash, startParentHash});
-        should.exist(r);
-        // TOOD: make assertions about report, however details are scant for
-        // $graphLookup
-      });
-    }); // end aggregateHistory
 
     describe('getMergeEventHashes', () => {
       it('produces a result', async () => {

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -276,29 +276,9 @@ describe('Continuity Storage', () => {
         pluginMethods.should.have.same.members(blockMethods);
       });
     });
-    describe('getConsensusProofPeers', () => {
-      it('produces a result', async () => {
-        const {getConsensusProofPeers} = _getBlockMethods();
-        const r = await getConsensusProofPeers({blockHeight: 1});
-        const [peer] = r;
-        // the only peer in this network
-        peer.should.equal(testCreatorIds[0]);
-      });
-      it('is indexed properly', async () => {
-        const {getConsensusProofPeers} = _getBlockMethods();
-        const r = await getConsensusProofPeers({blockHeight: 1, explain: true});
-        const {indexName} = r.stages[0].$cursor.queryPlanner
-          .winningPlan.inputStage;
-        ['block.continuity2017.blockHeight.1', 'block.blockHeight.core.1']
-          .should.include(indexName);
-      });
-    });
   }); // end block APIs
 });
 
-function _getBlockMethods() {
-  return ledgerNode.storage.blocks.plugins['continuity-storage'];
-}
 function _getEventMethods() {
   return ledgerNode.storage.events.plugins['continuity-storage'];
 }

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -14,7 +14,8 @@ const eventMethods = [
   'hasOutstandingParentHashCommitments',
   'hasOutstandingRegularEvents',
   'getAvgConsensusTime', 'getHead', 'getMergeEventHashes',
-  'getMergeEventPeers', 'setEffectiveConfiguration', '_stat'
+  'getMergeEventPeers', 'getMostRecentLocalEventNumber',
+  'setEffectiveConfiguration', '_stat'
 ];
 const testEventHashes = [];
 const testCreatorIds = [];
@@ -288,7 +289,8 @@ describe('Continuity Storage', () => {
         const r = await getConsensusProofPeers({blockHeight: 1, explain: true});
         const {indexName} = r.stages[0].$cursor.queryPlanner
           .winningPlan.inputStage;
-        indexName.should.equal('block.blockHeight.core.1');
+        ['block.continuity2017.blockHeight.1', 'block.blockHeight.core.1']
+          .should.include(indexName);
       });
     });
   }); // end block APIs

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -14,7 +14,7 @@ const eventMethods = [
   'aggregateHistory', 'hasOutstandingParentHashCommitments',
   'hasOutstandingRegularEvents',
   'getAvgConsensusTime', 'getHead', 'getMergeEventHashes',
-  'getMergeEventPeers', 'getStartHash', 'setEffectiveConfiguration', '_stat'
+  'getMergeEventPeers', 'setEffectiveConfiguration', '_stat'
 ];
 const testEventHashes = [];
 const testCreatorIds = [];
@@ -246,30 +246,6 @@ describe('Continuity Storage', () => {
         s.totalDocsExamined.should.equal(0);
       });
     }); // end getMergeEventPeers
-
-    // FIXME: skipped due to pending removal of this method
-    describe.skip('getStartHash', () => {
-      it('produces a result', async () => {
-        const {getStartHash} = _getEventMethods();
-        const [peerId] = testCreatorIds;
-        const targetGeneration = 1;
-        const r = await getStartHash({peerId, targetGeneration});
-        r.should.be.a.string;
-      });
-      it('is properly indexed', async () => {
-        const {getStartHash} = _getEventMethods();
-        const [peerId] = testCreatorIds;
-        const targetGeneration = 1;
-        const r = await getStartHash(
-          {peerId, explain: true, targetGeneration});
-        const {executionStats: s} = r;
-        const {indexName} = r.queryPlanner.winningPlan.inputStage.inputStage;
-        indexName.should.equal('event.continuity2017.type.1');
-        s.nReturned.should.equal(1);
-        s.totalKeysExamined.should.equal(1);
-        s.totalDocsExamined.should.equal(0);
-      });
-    }); // end getStartHash
 
     describe('hasOutstandingRegularEvents', () => {
       it('produces a result', async () => {


### PR DESCRIPTION
This call is required by the new bedrock-ledger-consensus-continuity code that sets the `nextLocalEventNumber`. Fixes a bug where the local event number wasn't initialized correctly when running with a single witness.